### PR TITLE
Add Spanish translation and update FilamentEditEnv plugin and component

### DIFF
--- a/resources/lang/en/edit-env.php
+++ b/resources/lang/en/edit-env.php
@@ -2,5 +2,7 @@
 
 // translations for Joaopaulolndev/FilamentEditEnv
 return [
-    //
+    'Change env file' => 'Change env file',
+    'Env file saved successfully!' => 'Env file saved successfully!',
+    'envFile' => 'envFile',
 ];

--- a/resources/lang/es/edit-env.php
+++ b/resources/lang/es/edit-env.php
@@ -1,0 +1,8 @@
+<?php
+
+// translations for Joaopaulolndev/FilamentEditEnv
+return [
+    'Change env file' => 'Modificar archivo env',
+    'Env file saved successfully!' => '¡Archivo Env guardado con éxito!',
+    'envFile' => 'archivoEnv',
+];

--- a/src/FilamentEditEnvPlugin.php
+++ b/src/FilamentEditEnvPlugin.php
@@ -17,6 +17,7 @@ class FilamentEditEnvPlugin implements Plugin
     use EvaluatesClosures;
 
     public bool | Closure | null $showButton = null;
+    public string | Closure | null $setIcon = null;
 
     public function getId(): string
     {
@@ -69,5 +70,17 @@ class FilamentEditEnvPlugin implements Plugin
         $this->showButton = $showButton;
 
         return $this;
+    }
+
+    public function setIcon(string | Closure $setIcon = 'heroicon-o-command-line'): static
+    {
+        $this->setIcon = $setIcon;
+
+        return $this;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->evaluate($this->setIcon) ?? 'heroicon-o-command-line';
     }
 }

--- a/src/Livewire/ChangeEnvFileComponent.php
+++ b/src/Livewire/ChangeEnvFileComponent.php
@@ -2,30 +2,39 @@
 
 namespace Joaopaulolndev\FilamentEditEnv\Livewire;
 
-use Filament\Actions\Action;
-use Filament\Actions\Concerns\InteractsWithActions;
-use Filament\Actions\Contracts\HasActions;
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
-use Filament\Notifications\Notification;
 use Livewire\Component;
+use Filament\Actions\Action;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Joaopaulolndev\FilamentEditEnv\FilamentEditEnvPlugin;
 
 class ChangeEnvFileComponent extends Component implements HasActions, HasForms
 {
     use InteractsWithActions;
     use InteractsWithForms;
 
+    public string $icon = '';
+
+    public function mount()
+    {
+        $this->icon = FilamentEditEnvPlugin::get()->getIcon();
+    }
+
     public function editAction()
     {
         return Action::make('env-action')
-            ->icon('heroicon-o-command-line')
+            ->icon($this->icon)
             ->iconButton()
             ->modalHeading(__('Change env file')) //@todo: need to create translation for this
             ->modalWidth('lg')
             ->form([
                 //@todo: change this to a code editor
                 Textarea::make('envFile')
+                    ->label(__('envFile')) //@todo: need to create translation for this
                     ->required()
                     //->default(file_get_contents(base_path('.env')))
                     ->autofocus(),


### PR DESCRIPTION
Modified English language file. Added Spanish language file. Updated FilamentEditEnvPlugin and ChangeEnvFileComponent to handle default icon.


## Icon configuration in ChangeEnvFileComponent

With this modification the `FilamentEditEnvPlugin`  plugin allows you to set a custom icon to be used in the  `ChangeEnvFileComponent`. By default, the icon is  `heroicon-o-command-line`. However, you can customize this icon using the `setIcon` method.

### Example of use

To set a custom icon, use the `setIcon` method. In the following example, the icon is set to `heroicon-o-cube-transparent`

```php
FilamentEditEnvPlugin::make()
    ->setIcon(fn () => 'heroicon-o-cube-transparent');